### PR TITLE
chore(deps): standardize monthly grouped dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,51 @@
+# Dependabot configuration — HomericIntelligence fleet baseline
+# Cadence: monthly. Grouping: minor+patch updates in one PR, major-version
+# bumps in their own PR for focused review. See the Dependabot options
+# reference for details.
+
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: "/"
+  - package-ecosystem: 'uv'
+    directory: '/'
     schedule:
-      interval: weekly
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: 'chore(ci)'
+    groups:
+      minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary

Standardize Dependabot configuration to the HomericIntelligence fleet baseline:

- **Cadence**: `monthly` — one batched update window per month.
- **Grouping**: all `minor`+`patch` updates in a single PR per ecosystem;
  `major`-version bumps get their own PR for focused review.
- **Consistent metadata**: `dependencies` labels, Conventional Commit prefixes
  (`chore(deps)` / `chore(ci)` / `chore(docker)`), per-ecosystem
  open-pull-requests-limit.

## Notes

- No YAML anchors (Dependabot does not support them) — config is explicit per
  ecosystem entry.
- Every Dependabot PR triggers this repo's required CI matrix, so each
  grouped update is container-CI tested before merge.
- Config committed with a verified (GPG) signature.