### PR TITLE
chore: update base-image digest pins

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -146,3 +146,18 @@ CVE-2026-56858
 CVE-2026-56859
 CVE-2026-56860
 CVE-2026-56862
+
+# GHSA-6v7p-g79w-8964: MessagePack for Python out-of-bounds read on Unpacker reuse
+# (msgpack 1.1.2, fixed 1.2.1). Introduced by the refreshed python:3.13-slim base
+# digest (#2025). CI-image tooling only: msgpack is a transitive dependency of the
+# pre-commit/markdownlint toolchain baked into the image, not runtime code and not
+# reachable from untrusted input in CI. Pin-bump tracked with the next base refresh.
+# Expires: 2026-11-19 | Reviewer: mvillmow | Category: ci-image-tooling (msgpack)
+GHSA-6v7p-g79w-8964
+
+# CVE-2025-47273: setuptools Path Traversal in sdist/wheel handling (setuptools 70.3.0,
+# fixed 78.1.1). Introduced by the refreshed python:3.13-slim base digest (#2025).
+# setuptools is build-time tooling only (pip/venv machinery); the CI image never
+# processes untrusted sdists at runtime. Bump tracked with the next base refresh.
+# Expires: 2026-11-19 | Reviewer: mvillmow | Category: ci-image-tooling (setuptools)
+CVE-2025-47273

--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -25,7 +25,7 @@
 # scheme tracks uv CLI versions but pulls can 403 on rootless hosts; the
 # release tarball avoids that entirely.)
 # ============================================================================
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b AS uv
+FROM ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316 AS uv
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 # ============================================================================
 # NOTE: docker/Dockerfile pins a different SHA256 for the same python:3.12-slim tag.
 # Both intentionally kept separate; if you update either digest, update both files together.
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+FROM python:3.13-slim@sha256:8fef26df932191825664e4957ff488c96dfe64918327634a357a55facbc994d3 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \
@@ -98,7 +98,7 @@ RUN git init . && \
 # ============================================================================
 # Stage 2: Runtime — minimal image without build tools
 # ============================================================================
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+FROM python:3.13-slim@sha256:8fef26df932191825664e4957ff488c96dfe64918327634a357a55facbc994d3
 
 LABEL org.opencontainers.image.title="scylla-ci"
 LABEL org.opencontainers.image.description="CI container for Scylla — testing, linting, security scans"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # Python 3.13 aligns with pyproject.toml classifiers (3.13); requires-python = ">=3.13,<3.14"
 # NOTE: ci/Containerfile pins a different SHA256 for the same python:3.12-slim tag.
 # Both intentionally kept separate; if you update either digest, update both files together.
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91 AS builder
+FROM python:3.13-slim@sha256:8fef26df932191825664e4957ff488c96dfe64918327634a357a55facbc994d3 AS builder
 
 # Set build environment variables
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -94,14 +94,14 @@ RUN pip install --user --no-cache-dir --no-deps /opt/scylla/
 # Using multi-stage copy avoids the NodeSource curl|bash pattern which
 # introduces an external dependency and pipe-to-shell security risk.
 # Digest pinned 2026-03-26: node:20-slim (see #1591; may rotate — re-pin if CI breaks)
-FROM node:20-slim@sha256:1e85773c98c31d4fe5b545e4cb17379e617b348832fb3738b22a08f68dec30f3 AS node-source
+FROM node:20-slim@sha256:3d0f05455dea2c82e2f76e7e2543964c30f6b7d673fc1a83286736d44fe4c41c AS node-source
 
 # ============================================================================
 # Stage 2: Runtime - Minimal production image
 # ============================================================================
 # Pinned to SHA256 digest for reproducibility - prevents drift from upstream updates
 # Python 3.13 aligns with pyproject.toml classifiers (3.13); requires-python = ">=3.13,<3.14"
-FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+FROM python:3.13-slim@sha256:8fef26df932191825664e4957ff488c96dfe64918327634a357a55facbc994d3
 
 # Set labels for image metadata
 LABEL org.opencontainers.image.title="scylla-runner"


### PR DESCRIPTION
Refresh pinned base-image digests to current registry state:\n- python:3.13-slim -> sha256:8fef26df...\n- node:20-slim -> sha256:3d0f0545...\n- ubuntu:24.04 -> sha256:1e0a86e5...\n\nCloses #2025