### PR TITLE
ci: canonical release check + advanced-setup CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+# CodeQL configuration for Scylla.
+# Scope analysis to first-party source; build artifacts, vendored deps, and
+# generated trees are third-party code we do not maintain (#2028, #455 rollout).
+name: "Scylla CodeQL config"
+
+paths-ignore:
+  - build/**
+  - "**/_deps/**"
+  - "**/node_modules/**"
+  - "**/.venv/**"
+  - dist/**
+  - vendor/**

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -525,3 +525,32 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
+
+  # ── 13. release (canonical dry-run) ─────────────────────────────────────
+  # Canonical `release` context per the 8-category naming scheme (#2027).
+  # Validates release-pipeline well-formedness on every PR/push WITHOUT
+  # publishing — real publishing stays tag-only in release.yml.
+  release:
+    name: release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Validate release workflow schema
+        run: |
+          pip install check-jsonschema
+          check-jsonschema \
+            --schemafile https://json.schemastore.org/github-workflow \
+            .github/workflows/release.yml
+      - name: Validate package version consistency
+        run: |
+          python3 - <<'PYEOF'
+          import tomllib
+          from pathlib import Path
+          py = tomllib.loads(Path("pyproject.toml").read_text())
+          version = py["project"]["version"]
+          assert version.count(".") >= 2, f"malformed version: {version}"
+          print(f"OK: pyproject version {version}")
+          PYEOF

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+# Fleet-standard CodeQL analysis (advanced setup) with canonical
+# security/codeql-<language> check names (#2028, part of
+# HomericIntelligence/Odysseus#455 rollout). Default setup was disabled when
+# this workflow landed.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: security/codeql-${{ matrix.language }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## release (#2027)\nAdds the canonical \`release\` context via a lightweight dry-run job in _required.yml (schema + version consistency checks, no publishing). Real publishing stays tag-only in release.yml.\n\n## CodeQL advanced setup (#2028)\nMigrates CodeQL from default setup to a committed workflow emitting \`security/codeql-python\` and \`security/codeql-actions\` (canonical 8-category security naming), with paths-ignore for build artifacts, mirroring the fleet rollout (HomericIntelligence/Odysseus#455). Default setup is disabled once this lands.\n\nCloses #2027\nCloses #2028