### PR TITLE
fix(ci): remediate tar vulnerability in pre-commit cache

### DIFF
--- a/ci/Containerfile
+++ b/ci/Containerfile
@@ -44,6 +44,9 @@ FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5
 ENV DEBIAN_FRONTEND=noninteractive \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # Keep the pre-commit cache at one absolute path in every stage. Its
+    # database and Node shims contain absolute paths and are not relocatable.
+    PRE_COMMIT_HOME=/opt/pre-commit-cache \
     # Build the project virtualenv in a fixed, copyable location.
     UV_PROJECT_ENVIRONMENT=/opt/scylla-venv \
     # Bytecode-compile on install for faster cold starts.
@@ -91,9 +94,27 @@ RUN uv sync --all-groups --all-extras --locked --no-install-project
 # without downloading hook repos or creating virtualenvs at CI time.
 # Hooks that use 'language: system' (uv run ...) just need uv + the venv available.
 # pre-commit install-hooks requires a git repo, so we init a temporary one.
+# markdownlint's nodeenv bundles npm, whose own tar dependency is not controlled
+# by uv.lock or .pre-commit-config.yaml. Patch that bundled copy to the first
+# version beyond the CVE-2026-73566 fix floor, using the npm registry tarball's
+# published integrity digest. Keep this in the hook-install RUN so no image
+# layer retains the vulnerable tar@7.5.19 tree.
+COPY ci/patch_precommit_node_tar.py /tmp/patch_precommit_node_tar.py
 RUN git init . && \
     uv run pre-commit install-hooks && \
-    rm -rf .git
+    curl -fsSL --retry 5 --retry-all-errors \
+        https://registry.npmjs.org/tar/-/tar-7.5.22.tgz \
+        -o /tmp/tar-7.5.22.tgz && \
+    echo "3053bf433bed00e9896e484e6824ef6c670537d2fd6fe26e9c8b03c1a2a58d239d70b31e6b7349d64f54b33feb8dd7d25d3ab875fcdf792ed6e29e1838000778  /tmp/tar-7.5.22.tgz" \
+        | sha512sum --check && \
+    mkdir /tmp/node-tar-package && \
+    tar xzf /tmp/tar-7.5.22.tgz -C /tmp/node-tar-package --strip-components=1 && \
+    python3 /tmp/patch_precommit_node_tar.py patch \
+        --cache-root "$PRE_COMMIT_HOME" \
+        --source /tmp/node-tar-package \
+        --expected-version 7.5.22 && \
+    rm -rf .git /tmp/node-tar-package /tmp/patch_precommit_node_tar.py \
+        /tmp/tar-7.5.22.tgz
 
 # ============================================================================
 # Stage 2: Runtime — minimal image without build tools
@@ -108,6 +129,7 @@ LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Sc
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
+    PRE_COMMIT_HOME=/opt/pre-commit-cache \
     UV_PROJECT_ENVIRONMENT=/opt/scylla-venv \
     UV_LINK_MODE=copy \
     UV_TOOL_DIR=/opt/uv-tools \
@@ -148,17 +170,14 @@ RUN curl -fsSL --retry 5 --retry-all-errors https://github.com/gitleaks/gitleaks
     && uv tool install check-jsonschema \
     && chmod -R a+rX /opt/uv-tools
 
-# Copy pre-commit hook cache from builder (baked-in hook envs)
-COPY --from=builder /root/.cache/pre-commit /root/.cache/pre-commit
-
 # Create non-root user for rootless Podman compatibility
 # UID 1000 is the default first user on most Linux systems, matching typical
 # developer UIDs for smooth volume mount permissions without --userns=keep-id
 RUN groupadd -r ci && useradd -r -g ci -u 1000 -m -s /bin/bash ci
 
-# Copy pre-commit cache to ci user's home (pre-commit uses $HOME/.cache)
-RUN cp -r /root/.cache/pre-commit /home/ci/.cache/ 2>/dev/null || true && \
-    chown -R ci:ci /home/ci/.cache
+# Preserve the cache's absolute path and give the final runtime user ownership.
+COPY --from=builder --chown=ci:ci /opt/pre-commit-cache /opt/pre-commit-cache
+COPY --chown=ci:ci ci/patch_precommit_node_tar.py /tmp/patch_precommit_node_tar.py
 
 # The baked venv was built with --no-install-project; at runtime `uv run`
 # installs the project (editable) into it, so the ci user must own it.
@@ -167,7 +186,14 @@ RUN chown -R ci:ci /opt/scylla-venv /opt/uv-tools
 # Working directory is the mounted repo root at runtime
 WORKDIR /workspace
 
+USER ci
+
+# Validate the active store as the final runtime user. This checks every npm
+# tar copy and executes markdownlint-cli2 from the same pre-commit cache.
+RUN python3 /tmp/patch_precommit_node_tar.py verify \
+        --cache-root "$PRE_COMMIT_HOME" \
+        --minimum-version 7.5.21 && \
+    rm /tmp/patch_precommit_node_tar.py
+
 # No ENTRYPOINT — commands are provided externally by CI or run_ci_local.sh
 # Example: podman run --rm -v .:/workspace:Z scylla-ci:local uv run pytest
-
-USER ci

--- a/ci/patch_precommit_node_tar.py
+++ b/ci/patch_precommit_node_tar.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Replace vulnerable npm-bundled tar copies in a pre-commit cache."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MINIMUM_FIXED_VERSION = (7, 5, 21)
+TARGET_PATTERN = "repo*/node_env-*/lib/node_modules/npm/node_modules/tar"
+MARKDOWNLINT_PATTERN = "repo*/node_env-*/bin/markdownlint-cli2"
+
+
+class PatchError(RuntimeError):
+    """Report an invalid or incomplete Node tar patch."""
+
+
+def _parse_version(value: str) -> tuple[int, int, int]:
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part.isdecimal() for part in parts):
+        raise PatchError(f"invalid tar version: {value!r}")
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def _package_version(directory: Path) -> str:
+    manifest = directory / "package.json"
+    if manifest.is_symlink() or not manifest.is_file():
+        raise PatchError(f"tar package manifest is not a regular file: {manifest}")
+
+    try:
+        package = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise PatchError(f"cannot read tar package manifest {manifest}: {error}") from error
+
+    if not isinstance(package, dict) or package.get("name") != "tar":
+        raise PatchError(f"unexpected npm package manifest: {manifest}")
+    version = package.get("version")
+    if not isinstance(version, str):
+        raise PatchError(f"tar package version is missing: {manifest}")
+    _parse_version(version)
+    return version
+
+
+def _find_targets(cache_root: Path) -> list[Path]:
+    targets = sorted(cache_root.glob(TARGET_PATTERN))
+    if not targets:
+        raise PatchError(f"no npm-bundled tar package found under {cache_root}")
+    for target in targets:
+        if target.is_symlink() or not target.is_dir():
+            raise PatchError(f"tar patch target is not a regular directory: {target}")
+    return targets
+
+
+def _require_active_cache(cache_root: Path) -> Path:
+    configured = os.environ.get("PRE_COMMIT_HOME")
+    if configured is None:
+        raise PatchError("PRE_COMMIT_HOME is not set")
+
+    active_root = Path(configured).resolve(strict=True)
+    requested_root = cache_root.resolve(strict=True)
+    if active_root != requested_root:
+        raise PatchError(
+            f"cache root {requested_root} does not match PRE_COMMIT_HOME {active_root}"
+        )
+    return active_root
+
+
+def _find_markdownlint(cache_root: Path) -> Path:
+    executables = sorted(cache_root.glob(MARKDOWNLINT_PATTERN))
+    if len(executables) != 1:
+        raise PatchError(
+            f"expected one markdownlint-cli2 under {cache_root}; found {len(executables)}"
+        )
+    executable = executables[0]
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise PatchError(f"markdownlint-cli2 is not executable: {executable}")
+    return executable
+
+
+def _run_markdownlint_smoke(executable: Path) -> None:
+    environment = os.environ.copy()
+    existing_path = environment.get("PATH")
+    environment["PATH"] = (
+        f"{executable.parent}{os.pathsep}{existing_path}"
+        if existing_path
+        else str(executable.parent)
+    )
+    with tempfile.TemporaryDirectory(prefix="scylla-markdownlint-") as directory:
+        document = Path(directory) / "README.md"
+        document.write_text("# CI image smoke test\n", encoding="utf-8")
+        try:
+            result = subprocess.run(
+                [str(executable), str(document)],
+                check=False,
+                capture_output=True,
+                cwd=directory,
+                env=environment,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise PatchError("markdownlint-cli2 smoke test timed out") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise PatchError(f"markdownlint-cli2 smoke test failed: {detail}")
+
+
+def patch_precommit_node_tar(cache_root: Path, source: Path, expected_version: str) -> int:
+    """Replace each npm-bundled tar directory and return the patched count."""
+    expected = _parse_version(expected_version)
+    if expected < MINIMUM_FIXED_VERSION:
+        raise PatchError(f"tar {expected_version} is below the CVE-2026-73566 fix floor 7.5.21")
+    if source.is_symlink() or not source.is_dir():
+        raise PatchError(f"tar patch source is not a regular directory: {source}")
+    source_version = _package_version(source)
+    if source_version != expected_version:
+        raise PatchError(f"tar patch source is {source_version}; expected {expected_version}")
+
+    targets = _find_targets(cache_root)
+
+    for target in targets:
+        staging = target.with_name(f".tar-{expected_version}-staging")
+        if staging.exists() or staging.is_symlink():
+            raise PatchError(f"tar patch staging path already exists: {staging}")
+        shutil.copytree(source, staging)
+        shutil.rmtree(target)
+        staging.replace(target)
+
+    for target in targets:
+        installed_version = _package_version(target)
+        if installed_version != expected_version:
+            raise PatchError(f"tar patch verification failed for {target}: {installed_version}")
+
+    return len(targets)
+
+
+def verify_precommit_node_tar(cache_root: Path, minimum_version: str) -> int:
+    """Verify the active cache's tar versions and execute its Markdown hook."""
+    minimum = _parse_version(minimum_version)
+    if minimum < MINIMUM_FIXED_VERSION:
+        raise PatchError(f"tar verification floor {minimum_version} is below 7.5.21")
+
+    active_root = _require_active_cache(cache_root)
+    targets = _find_targets(active_root)
+    for target in targets:
+        installed_version = _package_version(target)
+        if _parse_version(installed_version) < minimum:
+            raise PatchError(
+                f"tar verification failed for {target}: {installed_version} < {minimum_version}"
+            )
+
+    _run_markdownlint_smoke(_find_markdownlint(active_root))
+    return len(targets)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    patch = commands.add_parser("patch", help="replace npm-bundled tar packages")
+    patch.add_argument("--cache-root", type=Path, required=True)
+    patch.add_argument("--source", type=Path, required=True)
+    patch.add_argument("--expected-version", required=True)
+
+    verify = commands.add_parser("verify", help="validate the active pre-commit cache")
+    verify.add_argument("--cache-root", type=Path, required=True)
+    verify.add_argument("--minimum-version", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the command-line patch operation."""
+    args = _parse_args()
+    try:
+        if args.command == "patch":
+            count = patch_precommit_node_tar(
+                args.cache_root,
+                args.source,
+                args.expected_version,
+            )
+            message = f"patched {count} npm-bundled tar package(s) to {args.expected_version}"
+        else:
+            count = verify_precommit_node_tar(args.cache_root, args.minimum_version)
+            message = (
+                f"verified {count} npm-bundled tar package(s) at or above "
+                f"{args.minimum_version}; markdownlint-cli2 passed"
+            )
+    except (OSError, PatchError) as error:
+        sys.stderr.write(f"error: {error}\n")
+        return 1
+
+    sys.stdout.write(f"{message}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/ci/test_patch_precommit_node_tar.py
+++ b/tests/unit/ci/test_patch_precommit_node_tar.py
@@ -1,0 +1,270 @@
+"""Behavior tests for the CI image's pre-commit Node tar patch."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PATCH_SCRIPT = PROJECT_ROOT / "ci" / "patch_precommit_node_tar.py"
+CONTAINERFILE = PROJECT_ROOT / "ci" / "Containerfile"
+FIXED_TAR_VERSION = "7.5.22"
+FIXED_TAR_SHA512 = (
+    "3053bf433bed00e9896e484e6824ef6c670537d2fd6fe26e9c8b03c1a2a58d239"
+    "d70b31e6b7349d64f54b33feb8dd7d25d3ab875fcdf792ed6e29e1838000778"
+)
+
+
+def _write_package(directory: Path, version: str) -> None:
+    directory.mkdir(parents=True)
+    (directory / "package.json").write_text(
+        json.dumps({"name": "tar", "version": version}),
+        encoding="utf-8",
+    )
+    (directory / "index.js").write_text("module.exports = {};\n", encoding="utf-8")
+
+
+def _run_patch(cache_root: Path, source: Path, version: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(PATCH_SCRIPT),
+            "patch",
+            "--cache-root",
+            str(cache_root),
+            "--source",
+            str(source),
+            "--expected-version",
+            version,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_markdownlint(cache_root: Path) -> None:
+    executable = cache_root / "repo-one" / "node_env-default" / "bin" / "markdownlint-cli2"
+    executable.parent.mkdir(parents=True)
+    node = executable.parent / "node"
+    node.write_text(
+        f"#!{sys.executable}\n"
+        "from pathlib import Path\n"
+        "import sys\n"
+        "document = Path(sys.argv[2])\n"
+        "raise SystemExit(0 if document.read_text() == '# CI image smoke test\\n' else 2)\n",
+        encoding="utf-8",
+    )
+    node.chmod(0o755)
+    executable.write_text(
+        "#!/usr/bin/env node\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+
+
+def _run_verify(
+    cache_root: Path,
+    minimum_version: str,
+    *,
+    active_cache_root: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(PATCH_SCRIPT),
+            "verify",
+            "--cache-root",
+            str(cache_root),
+            "--minimum-version",
+            minimum_version,
+        ],
+        check=False,
+        capture_output=True,
+        env={
+            **os.environ,
+            "PATH": "/usr/bin:/bin",
+            "PRE_COMMIT_HOME": str(active_cache_root or cache_root),
+        },
+        text=True,
+    )
+
+
+def test_replaces_every_npm_bundled_tar_copy(tmp_path: Path) -> None:
+    """The patch replaces all npm-bundled tar copies in the pre-commit cache."""
+    source = tmp_path / "source"
+    cache_root = tmp_path / "cache"
+    targets = [
+        cache_root
+        / repo
+        / "node_env-default"
+        / "lib"
+        / "node_modules"
+        / "npm"
+        / "node_modules"
+        / "tar"
+        for repo in ("repo-one", "repo-two")
+    ]
+    _write_package(source, "7.5.22")
+    for target in targets:
+        _write_package(target, "7.5.19")
+
+    result = _run_patch(cache_root, source, "7.5.22")
+
+    assert result.returncode == 0, result.stderr
+    for target in targets:
+        package = json.loads((target / "package.json").read_text(encoding="utf-8"))
+        assert package["version"] == "7.5.22"
+        assert (target / "index.js").is_file()
+
+
+def test_verify_uses_active_cache_and_runs_markdownlint(tmp_path: Path) -> None:
+    """Runtime verification uses PRE_COMMIT_HOME and executes its Markdown hook."""
+    cache_root = tmp_path / "pre-commit-cache"
+    target = (
+        cache_root
+        / "repo-one"
+        / "node_env-default"
+        / "lib"
+        / "node_modules"
+        / "npm"
+        / "node_modules"
+        / "tar"
+    )
+    _write_package(target, "7.5.22")
+    _write_markdownlint(cache_root)
+
+    result = _run_verify(cache_root, "7.5.21")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_verify_rejects_a_cache_other_than_precommit_home(tmp_path: Path) -> None:
+    """Runtime verification cannot validate an inactive cache by mistake."""
+    cache_root = tmp_path / "candidate-cache"
+    active_cache_root = tmp_path / "active-cache"
+    target = (
+        cache_root
+        / "repo-one"
+        / "node_env-default"
+        / "lib"
+        / "node_modules"
+        / "npm"
+        / "node_modules"
+        / "tar"
+    )
+    _write_package(target, "7.5.22")
+    _write_markdownlint(cache_root)
+    active_cache_root.mkdir()
+
+    result = _run_verify(
+        cache_root,
+        "7.5.21",
+        active_cache_root=active_cache_root,
+    )
+
+    assert result.returncode != 0
+    assert "does not match PRE_COMMIT_HOME" in result.stderr
+
+
+def test_verify_rejects_vulnerable_tar_in_the_active_cache(tmp_path: Path) -> None:
+    """The active cache fails verification when npm still contains vulnerable tar."""
+    cache_root = tmp_path / "pre-commit-cache"
+    target = (
+        cache_root
+        / "repo-one"
+        / "node_env-default"
+        / "lib"
+        / "node_modules"
+        / "npm"
+        / "node_modules"
+        / "tar"
+    )
+    _write_package(target, "7.5.19")
+    _write_markdownlint(cache_root)
+
+    result = _run_verify(cache_root, "7.5.21")
+
+    assert result.returncode != 0
+    assert "7.5.19 < 7.5.21" in result.stderr
+
+
+def test_fails_closed_when_no_npm_bundled_tar_exists(tmp_path: Path) -> None:
+    """An empty cache cannot produce a successful patch result."""
+    source = tmp_path / "source"
+    cache_root = tmp_path / "cache"
+    _write_package(source, "7.5.22")
+    cache_root.mkdir()
+
+    result = _run_patch(cache_root, source, "7.5.22")
+
+    assert result.returncode != 0
+
+
+def test_rejects_a_source_below_the_security_floor(tmp_path: Path) -> None:
+    """The patch rejects tar versions that do not fix CVE-2026-73566."""
+    source = tmp_path / "source"
+    cache_root = tmp_path / "cache"
+    target = (
+        cache_root
+        / "repo-one"
+        / "node_env-default"
+        / "lib"
+        / "node_modules"
+        / "npm"
+        / "node_modules"
+        / "tar"
+    )
+    _write_package(source, "7.5.19")
+    _write_package(target, "7.5.19")
+
+    result = _run_patch(cache_root, source, "7.5.19")
+
+    assert result.returncode != 0
+    package = json.loads((target / "package.json").read_text(encoding="utf-8"))
+    assert package["version"] == "7.5.19"
+
+
+def test_container_patches_tar_in_the_hook_install_layer() -> None:
+    """The vulnerable hook cache never survives in an intermediate image layer."""
+    text = CONTAINERFILE.read_text(encoding="utf-8")
+    hook_layer = text.split("RUN git init .", maxsplit=1)[1].split("\n\n", maxsplit=1)[0]
+
+    assert "COPY ci/patch_precommit_node_tar.py /tmp/patch_precommit_node_tar.py" in text
+    assert "uv run pre-commit install-hooks" in hook_layer
+    assert f"tar-{FIXED_TAR_VERSION}.tgz" in hook_layer
+    assert FIXED_TAR_SHA512 in hook_layer
+    assert "python3 /tmp/patch_precommit_node_tar.py patch" in hook_layer
+    assert '--cache-root "$PRE_COMMIT_HOME"' in hook_layer
+    assert f"--expected-version {FIXED_TAR_VERSION}" in hook_layer
+
+
+def test_final_ci_user_uses_the_patched_cache_at_its_build_path() -> None:
+    """The final ci user consumes and validates the cache without relocating it."""
+    text = CONTAINERFILE.read_text(encoding="utf-8")
+    builder_stage = text.split(" AS builder", maxsplit=1)[1].split("\nFROM ", maxsplit=1)[0]
+    runtime_stage = text.rsplit("\nFROM ", maxsplit=1)[1]
+    builder_home = re.search(r"PRE_COMMIT_HOME=([^ \\\n]+)", builder_stage)
+    runtime_home = re.search(r"PRE_COMMIT_HOME=([^ \\\n]+)", runtime_stage)
+
+    assert builder_home is not None, "builder must set PRE_COMMIT_HOME"
+    assert runtime_home is not None, "runtime must set PRE_COMMIT_HOME"
+    cache_root = builder_home.group(1)
+    assert cache_root == runtime_home.group(1)
+    assert cache_root.startswith("/")
+
+    copy = f"COPY --from=builder --chown=ci:ci {cache_root} {cache_root}"
+    assert copy in runtime_stage
+    assert '--cache-root "$PRE_COMMIT_HOME"' in builder_stage
+    assert "cp -r /root/.cache/pre-commit" not in runtime_stage
+    assert "2>/dev/null || true" not in runtime_stage
+
+    user_index = runtime_stage.index("USER ci")
+    verify_index = runtime_stage.index("patch_precommit_node_tar.py verify")
+    assert user_index < verify_index
+    assert '--cache-root "$PRE_COMMIT_HOME"' in runtime_stage
+    assert "--minimum-version 7.5.21" in runtime_stage


### PR DESCRIPTION
## Summary

Repairs CVE-2026-73566 at its authoritative source in the Scylla CI image. The image now replaces every npm-bundled vulnerable tar copy with checksum-pinned tar 7.5.22 and validates the exact pre-commit cache under the final unprivileged `ci` user.

## Changes

- Keep builder and runtime on one absolute `PRE_COMMIT_HOME` path.
- Download tar 7.5.22 with its pinned npm SHA-512 integrity value and replace every matched npm-bundled copy in the same build layer.
- Fail closed on missing, non-regular, version-mismatched, or sub-floor targets.
- Verify the relocated cache after `USER ci` and execute markdownlint through its cached Node environment.
- Add focused regression coverage for replacement, integrity, active-cache identity, final-user behavior, version floors, and failure cases.

## Related Issues

Closes #2102

Related to #2100 (the workflow path-filter follow-up remains intentionally separate because workflow edits require human approval).
Related to #2104 (temporary git-fixture isolation discovered by the enabled pre-push hook).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (code improvement without changing functionality)
- [ ] Breaking change (fix or feature which causes existing functionality to change)
- [ ] Documentation update
- [x] CI/CD or infrastructure change
- [x] Test coverage improvement

## Testing

- [x] Full enabled pre-push suite: 5,023 passed, 4 skipped; 79.20% coverage.
- [x] Focused supply-chain tests: 8 passed.
- [x] Scoped CI/Docker tests: 156 passed.
- [x] Ruff, mypy, and `git diff --check` passed.
- [x] Real relocated pre-commit cache verified; markdownlint executed from that cache.
- [x] Trivy reproduced tar 7.5.19 as vulnerable and reported zero HIGH/CRITICAL findings for the patched tar 7.5.22 directory.

The exact final amd64 OCI image and saved-image Trivy result remain required CI evidence because the local arm64 Podman VM crashed in QEMU during `uv sync`.

## Checklist

- [x] Code follows project style guidelines.
- [x] Independent change review completed with GO/no findings.
- [x] Comments added around supply-chain and cache invariants.
- [x] No vulnerability suppression or `.trivyignore` change.
- [x] No workflow file changed.
- [x] Conventional signed commit with matching DCO sign-off.
- [x] Branch follows `<issue-number>-<description>`.

## Review note

Please keep this PR human-reviewed. Do not merge a suppression-based alternative: the vulnerable tar package is removed here rather than ignored.